### PR TITLE
Added jailbreak dectection logic using SafetyNet and RootBeer

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -98,5 +98,9 @@ dependencies {
     })
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support.constraint:constraint-layout:2.0.4'
+    implementation 'com.google.android.gms:play-services-safetynet:18.0.1'
+    implementation 'androidx.appcompat:appcompat:1.0.2'
+    implementation 'androidx.annotation:annotation:1.0.2'
+    implementation 'com.scottyab:rootbeer-lib:0.1.0'
     testImplementation 'junit:junit:4.13.1'
 }

--- a/app/src/main/java/eu/pharmaledger/epi/MainActivity.java
+++ b/app/src/main/java/eu/pharmaledger/epi/MainActivity.java
@@ -1,15 +1,15 @@
 package eu.pharmaledger.epi;
 
 import android.Manifest;
+import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
-import android.support.annotation.RequiresApi;
-import android.support.v4.app.ActivityCompat;
-import android.support.v4.content.ContextCompat;
-import android.support.v7.app.AlertDialog;
-import android.support.v7.app.AppCompatActivity;
+import androidx.annotation.RequiresApi;
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
+import androidx.appcompat.app.AppCompatActivity;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.KeyEvent;
@@ -30,9 +30,12 @@ import android.widget.ProgressBar;
 import java.io.*;
 import java.net.ServerSocket;
 import java.nio.file.Files;
+import java.text.MessageFormat;
 import java.util.Arrays;
 
 import org.json.JSONObject;
+
+import eu.pharmaledger.epi.jailbreak.JailbreakDetection;
 
 public class MainActivity extends AppCompatActivity {
     public static String TAG = MainActivity.class.getCanonicalName();
@@ -281,6 +284,14 @@ public class MainActivity extends AppCompatActivity {
                         }
 
                         if (nodeDirReference.exists()) {
+                            String jailbreakDetectedFilePath = WEBSERVER_PATH + "/external-volume/jailbreak/jailbreak-detected";
+                            File jailbreakDetectedFile = new File(jailbreakDetectedFilePath);
+                            if(!jailbreakDetectedFile.exists()) {
+                                Log.i(TAG, MessageFormat.format("{0} doesn't exist. Checking for jailbreak...", jailbreakDetectedFilePath));
+                                JailbreakDetection jailbreakDetection = new JailbreakDetection();
+                                jailbreakDetection.detect(getApplicationContext(), jailbreakDetectedFile);
+                            }
+
                             Log.i(TAG, "Initiate startNodeWithArguments(...) call");
 
                             JSONObject env = new JSONObject();

--- a/app/src/main/java/eu/pharmaledger/epi/jailbreak/JailbreakDetection.java
+++ b/app/src/main/java/eu/pharmaledger/epi/jailbreak/JailbreakDetection.java
@@ -1,0 +1,113 @@
+package eu.pharmaledger.epi.jailbreak;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.util.Base64;
+import android.util.Log;
+
+import com.google.android.gms.common.api.ApiException;
+import com.google.android.gms.safetynet.SafetyNet;
+import com.google.android.gms.safetynet.SafetyNetApi;
+import com.google.android.gms.tasks.OnFailureListener;
+import com.google.android.gms.tasks.OnSuccessListener;
+import com.scottyab.rootbeer.RootBeer;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.security.SecureRandom;
+import java.text.MessageFormat;
+
+import eu.pharmaledger.epi.R;
+
+public class JailbreakDetection {
+    private static final String TAG = JailbreakDetection.class.getCanonicalName();
+
+    public void detect(final Context applicationContext, final File jailbreakDetectedFile) {
+        String apiKey = applicationContext.getString(R.string.safety_net_api_key);
+
+        // The nonce should be at least 16 bytes in length.
+        // You must generate the value of API_KEY in the Google APIs dashboard.
+        SafetyNet.getClient(applicationContext).attest(generateNonce(), apiKey)
+                .addOnSuccessListener(new OnSuccessListener<SafetyNetApi.AttestationResponse>() {
+                    @Override
+                    public void onSuccess(SafetyNetApi.AttestationResponse response) {
+                        // Indicates communication with the service was successful.
+                        // Use response.getJwsResult() to get the result data.
+                        String result = decodeJws(response.getJwsResult());
+                        Log.i(TAG, "Received result from SafetyNet: " + result);
+                        JailbreakInfo jailbreakInfo = JailbreakInfo.fromSafetyNetResponse(result);
+                        addAdditionalRootBeerInfoIfRootedDevice(applicationContext, jailbreakInfo);
+                        writeJailbreakInfoToFile(jailbreakDetectedFile, jailbreakInfo);
+                    }
+                })
+                .addOnFailureListener(new OnFailureListener() {
+                    @Override
+                    public void onFailure(Exception e) {
+                        // An error occurred while communicating with the service.
+                        if (e instanceof ApiException) {
+                            // An error with the Google Play services API contains some
+                            // additional details.
+                            ApiException apiException = (ApiException) e;
+                            Log.e(TAG, MessageFormat.format("An error has occurred with Google Play services, error {0}",
+                                    apiException.getStatusCode()), e);
+                        } else {
+                            Log.e(TAG, MessageFormat.format("An error unknown has occurred with Google Play services, error {0}",
+                                    e.getMessage()), e);
+
+                        }
+
+                        JailbreakInfo jailbreakInfo = new JailbreakInfo();
+                        addAdditionalRootBeerInfoIfRootedDevice(applicationContext, jailbreakInfo);
+                        writeJailbreakInfoToFile(jailbreakDetectedFile, jailbreakInfo);
+                    }
+                });
+    }
+
+    private void addAdditionalRootBeerInfoIfRootedDevice(Context applicationContext, JailbreakInfo jailbreakInfo) {
+        final RootBeer rootBeer = new RootBeer(applicationContext);
+        if (rootBeer.isRooted()) {
+            Log.i(TAG, "Device is rooted!");
+            JailbreakInfo.fromRootBeer(rootBeer, jailbreakInfo);
+        } else {
+            Log.i(TAG, "Didn't find indication of rooted device!");
+        }
+    }
+
+    private void writeJailbreakInfoToFile(File jailbreakDetectedFile, JailbreakInfo jailbreakInfo) {
+        if (!jailbreakInfo.isRootedDevice()) {
+            Log.i(TAG, "Device not seen as rooted device so skip jailbreak info file write");
+            return;
+        }
+        if (!jailbreakDetectedFile.getParentFile().exists()) {
+            jailbreakDetectedFile.getParentFile().mkdirs();
+        }
+
+        String json = jailbreakInfo.toJSON();
+        Log.i(TAG, MessageFormat.format("Writing jailbreak info ({0}) to file {1}", json, jailbreakDetectedFile.getAbsolutePath()));
+        try (FileWriter fileWriter = new FileWriter(jailbreakDetectedFile, false)) {
+            fileWriter.write(json);
+        } catch (Exception exception) {
+            Log.e(TAG, MessageFormat.format("Failed to write: {0}", jailbreakDetectedFile.getAbsolutePath()), exception);
+        }
+    }
+
+    private String decodeJws(String jwsResult) {
+        if (jwsResult == null) {
+            return "";
+        }
+        final String[] jwtParts = jwsResult.split("\\.");
+        if (jwtParts.length == 3) {
+            String decodedPayload = new String(Base64.decode(jwtParts[1], Base64.DEFAULT));
+            return decodedPayload;
+        } else {
+            return "";
+        }
+    }
+
+    private byte[] generateNonce() {
+        SecureRandom secureRandom = new SecureRandom();
+        byte[] nonce = new byte[16];
+        secureRandom.nextBytes(nonce);
+        return nonce;
+    }
+}

--- a/app/src/main/java/eu/pharmaledger/epi/jailbreak/JailbreakInfo.java
+++ b/app/src/main/java/eu/pharmaledger/epi/jailbreak/JailbreakInfo.java
@@ -1,0 +1,109 @@
+package eu.pharmaledger.epi.jailbreak;
+
+import android.util.JsonReader;
+import android.util.JsonWriter;
+import android.util.Log;
+
+import com.scottyab.rootbeer.RootBeer;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStreamReader;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+
+public class JailbreakInfo {
+    public static String TAG = JailbreakInfo.class.getCanonicalName();
+    private Boolean ctsProfileMatch;
+    private Boolean basicIntegrity;
+    private Boolean isRooted;
+    private Boolean rootManagementApps;
+    private Boolean potentiallyDangerousApps;
+    private Boolean rootCloakingApps;
+    private Boolean testKeys;
+    private Boolean dangerousProps;
+    private Boolean busyBoxBinary;
+    private Boolean suBinary;
+    private Boolean suExists;
+    private Boolean rwPaths;
+
+    public static JailbreakInfo fromSafetyNetResponse(String response) {
+        JailbreakInfo info = new JailbreakInfo();
+
+        try (JsonReader reader = new JsonReader(new InputStreamReader(new ByteArrayInputStream(response.getBytes()), StandardCharsets.UTF_8))) {
+            reader.beginObject();
+            while (reader.hasNext()) {
+                String fieldName = reader.nextName();
+                if (fieldName.equalsIgnoreCase("ctsProfileMatch")) {
+                    info.ctsProfileMatch = reader.nextBoolean();
+                } else if (fieldName.equalsIgnoreCase("basicIntegrity")) {
+                    info.basicIntegrity = reader.nextBoolean();
+                } else {
+                    reader.skipValue();
+                }
+            }
+            reader.endObject();
+
+            return info;
+        } catch (Exception exception) {
+            Log.e(TAG, "Failed to parse SafetyNet response: " + response, exception);
+        }
+
+        return info;
+    }
+
+    public static JailbreakInfo fromRootBeer(RootBeer rootBeer) {
+        return fromRootBeer(rootBeer, new JailbreakInfo());
+    }
+
+    public static JailbreakInfo fromRootBeer(RootBeer rootBeer, JailbreakInfo info) {
+        info.isRooted = true;
+        info.rootManagementApps = rootBeer.detectRootManagementApps();
+        info.potentiallyDangerousApps = rootBeer.detectPotentiallyDangerousApps();
+        info.rootCloakingApps = rootBeer.detectRootCloakingApps();
+        info.testKeys = rootBeer.detectTestKeys();
+        info.dangerousProps = rootBeer.checkForDangerousProps();
+        info.busyBoxBinary = rootBeer.checkForBusyBoxBinary();
+        info.suBinary = rootBeer.checkForSuBinary();
+        info.suExists = rootBeer.checkSuExists();
+        info.rwPaths = rootBeer.checkForRWPaths();
+
+        return info;
+    }
+
+    private static void setJsonWriterBooleanField(JsonWriter writer, String fieldName, Boolean value) throws Exception {
+        if (value != null) {
+            writer.name(fieldName).value(value);
+        } else {
+            writer.name(fieldName).nullValue();
+        }
+    }
+
+    public boolean isRootedDevice() {
+        return (Boolean.FALSE.equals(ctsProfileMatch) && Boolean.FALSE.equals(basicIntegrity)) || Boolean.TRUE.equals(isRooted);
+    }
+
+    public String toJSON() {
+        String json = "{}";
+        try (StringWriter sw = new StringWriter(); JsonWriter writer = new JsonWriter(sw)) {
+            writer.beginObject();
+            setJsonWriterBooleanField(writer, "ctsProfileMatch", ctsProfileMatch);
+            setJsonWriterBooleanField(writer, "basicIntegrity", basicIntegrity);
+            setJsonWriterBooleanField(writer, "isRooted", isRooted);
+            setJsonWriterBooleanField(writer, "rootManagementApps", rootManagementApps);
+            setJsonWriterBooleanField(writer, "potentiallyDangerousApps", potentiallyDangerousApps);
+            setJsonWriterBooleanField(writer, "rootCloakingApps", rootCloakingApps);
+            setJsonWriterBooleanField(writer, "testKeys", testKeys);
+            setJsonWriterBooleanField(writer, "dangerousProps", dangerousProps);
+            setJsonWriterBooleanField(writer, "busyBoxBinary", busyBoxBinary);
+            setJsonWriterBooleanField(writer, "suBinary", suBinary);
+            setJsonWriterBooleanField(writer, "suExists", suExists);
+            setJsonWriterBooleanField(writer, "rwPaths", rwPaths);
+            writer.endObject();
+
+            json = sw.toString();
+        } catch (Exception exception) {
+            Log.e(TAG, "Failed to generate jailbreak detected file content", exception);
+        }
+        return json;
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -42,4 +42,4 @@
     </LinearLayout>
 
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">EPI</string>
+    <string name="safety_net_api_key">GOOGLE_KEY</string>
 </resources>

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,5 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+android.useAndroidX=true
+android.enableJetifier=true


### PR DESCRIPTION
### **"Official" Android system detection:**
https://developer.android.com/training/safetynet/attestation

- The API is not designed to fulfill the following use cases:
	Purely to check whether the device is rooted, as the API is designed to check the overall integrity of the device.
- can only be used with online access
- requires Google API key

- Requires **AndroidX** libraries support (https://developer.android.com/jetpack/androidx/migrate)
- https://developer.android.com/training/safetynet/deprecation-timeline - As we move to further improve the portfolio of anti-abuse solutions, we plan to gradually turn down the SafetyNet Attestation API starting in June 2023. The timeline should give you enough time to migrate to the new Play Integrity API and avoid disruptions to your business.


### RootBeer
https://github.com/scottyab/rootbeer
- one of the most popular root detecting library
- can be used for offline usage
- on rooted devices, the library can be hacked to skip checks

### Current approach logic
Use SafetyNet logic. If it manages to load required information, then also try to get information via RootBeer.
If SafetyNet detection fails, then use only RootBeer.

If in the end, SafetyNet detect issues (ctsProfileMatch = false and basicIntegrity = false) or RootBeer detects issue (isRooted = true), then a file is created at **external-volume/jailbreak/jailbreak-detected**

### Sample output:

2022-07-31 20:43:24.600 31248-31248/eu.pharmaledger.epi I/eu.pharmaledger.epi.jailbreak.JailbreakDetection: Writing jailbreak info ({"ctsProfileMatch":false,"basicIntegrity":false,"isRooted":null,"rootManagementApps":null,"potentiallyDangerousApps":null,"rootCloakingApps":null,"testKeys":null,"dangerousProps":null,"busyBoxBinary":null,"suBinary":null,"suExists":null,"rwPaths":null}) to file /data/data/eu.pharmaledger.epi/files/nodejs-project/apihub-root/external-volume/jailbreak/jailbreak-detected


### Issues
1. **SafetyNet** requires **AndroidX** library support - this triggered some changes inside this PR (enabling AndroidX and update some imports)
2. A Google API key with **Android Device Verification API** enabled is required inside _app\src\main\res\values\strings.xml_
3. **SafetyNet** will be moved to another API and will be decommissioned on June 2023